### PR TITLE
Move repo/module from IBM to CycloneDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ integrate it in your own tools.
 Install the `license-scanner` CLI executable in your go environment by building from source with `go install`:
 
 ```bash
-go install github.com/IBM/license-scanner@latest
+go install github.com/CycloneDX/license-scanner@latest
 ```
 
 ### Installing for developers
@@ -32,7 +32,7 @@ For developers, `git clone` the repo and build the source code with `go build`:
 Clone the repo:
 
 ```bash
-git clone https://github.com/IBM/license-scanner.git
+git clone https://github.com/CycloneDX/license-scanner.git
 ```
 
 The commands that follow are to be run from your cloned repo root directory:
@@ -66,13 +66,13 @@ go install
 Using the `license-scanner` API is simple. First, use `go get` to install the latest version of the library.
 
 ```bash
-go get -u github.com/IBM/license-scanner@latest
+go get -u github.com/CycloneDX/license-scanner@latest
 ```
 
 Next, import the scanner API into your application:
 
 ```bash
-import "github.com/IBM/license-scanner/api/scanner"
+import "github.com/CycloneDX/license-scanner/api/scanner"
 ```
 
 ## CLI usage
@@ -204,7 +204,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/IBM/license-scanner/api/scanner"
+	"github.com/CycloneDX/license-scanner/api/scanner"
 )
 
 func GetLicense(urls map[string]string) {
@@ -331,8 +331,8 @@ Optional flags maybe used with the API to locate the config file and control run
 package main
 
 import (
-	"github.com/IBM/license-scanner/api/scanner"
-	"github.com/IBM/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/api/scanner"
+	"github.com/CycloneDX/license-scanner/configurer"
 )
 
 func main() {
@@ -477,15 +477,15 @@ Each package has many `unit` tests in `*_test.go` which can be executed using `g
 
 ```bash
  go test ./... -tags=unit
-?       github.com/IBM/license-scanner    [no test files]
-ok      github.com/IBM/license-scanner/api/scanner        3.009s
-ok      github.com/IBM/license-scanner/cmd        8.646s
-?       github.com/IBM/license-scanner/debugger   [no test files]
-ok      github.com/IBM/license-scanner/identifier 20.923s
-ok      github.com/IBM/license-scanner/licenses   7.151s
-?       github.com/IBM/license-scanner/logging    [no test files]
-ok      github.com/IBM/license-scanner/normalizer 0.161s
-ok      github.com/IBM/license-scanner/resources  0.278s
+?       github.com/CycloneDX/license-scanner    [no test files]
+ok      github.com/CycloneDX/license-scanner/api/scanner        3.009s
+ok      github.com/CycloneDX/license-scanner/cmd        8.646s
+?       github.com/CycloneDX/license-scanner/debugger   [no test files]
+ok      github.com/CycloneDX/license-scanner/identifier 20.923s
+ok      github.com/CycloneDX/license-scanner/licenses   7.151s
+?       github.com/CycloneDX/license-scanner/logging    [no test files]
+ok      github.com/CycloneDX/license-scanner/normalizer 0.161s
+ok      github.com/CycloneDX/license-scanner/resources  0.278s
 ```
 
 ## Importing SPDX license templates

--- a/api/scanner/scan.go
+++ b/api/scanner/scan.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/IBM/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/configurer"
 
-	"github.com/IBM/license-scanner/identifier"
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/identifier"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 // NOASSERTION_SPDX_NAME in License SPDX Name signify that the license text passed through the scan without any errors but no match was found

--- a/api/scanner/scan_resources_test.go
+++ b/api/scanner/scan_resources_test.go
@@ -7,8 +7,8 @@ package scanner_test
 import (
 	"testing"
 
-	"github.com/IBM/license-scanner/api/scanner"
-	"github.com/IBM/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/api/scanner"
+	"github.com/CycloneDX/license-scanner/configurer"
 
 	"golang.org/x/exp/slices"
 )

--- a/api/scanner/scan_test.go
+++ b/api/scanner/scan_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/IBM/license-scanner/api/scanner"
-	"github.com/IBM/license-scanner/configurer"
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/api/scanner"
+	"github.com/CycloneDX/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 func TestScanSpecs_ScanLicenseText(t *testing.T) {

--- a/cmd/license-scanner.md
+++ b/cmd/license-scanner.md
@@ -17,7 +17,7 @@ Example usage to scan LICENSE.txt, but only print the license IDs and positions 
 
     $ license-scanner --quiet -f LICENSE.txt
 
-Please give us feedback at: https://github.com/IBM/license-scanner/issues
+Please give us feedback at: https://github.com/CycloneDX/license-scanner/issues
 		
 
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,11 +14,11 @@ import (
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
 
-	"github.com/IBM/license-scanner/configurer"
-	"github.com/IBM/license-scanner/debugger"
-	"github.com/IBM/license-scanner/identifier"
-	"github.com/IBM/license-scanner/importer"
-	"github.com/IBM/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/debugger"
+	"github.com/CycloneDX/license-scanner/identifier"
+	"github.com/CycloneDX/license-scanner/importer"
+	"github.com/CycloneDX/license-scanner/licenses"
 )
 
 const (
@@ -54,7 +54,7 @@ Example usage to scan LICENSE.txt, but only print the license IDs and positions 
 
     $ license-scanner --quiet -f LICENSE.txt
 
-Please give us feedback at: https://github.com/IBM/license-scanner/issues
+Please give us feedback at: https://github.com/CycloneDX/license-scanner/issues
 		`,
 		Args:    cobra.NoArgs,
 		Version: currentVersion,

--- a/debugger/debug.go
+++ b/debugger/debug.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 // TODO: Commit to history, but if this is not being used anywhere, we should delete it.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/IBM/license-scanner
+module github.com/CycloneDX/license-scanner
 
 go 1.18
 

--- a/identifier/enhancer.go
+++ b/identifier/enhancer.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/IBM/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/licenses"
 )
 
 type Enhancements struct {

--- a/identifier/enhancer_test.go
+++ b/identifier/enhancer_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/IBM/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/licenses"
 )
 
 type test struct {

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -17,8 +17,8 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 var (

--- a/identifier/identifier_spdx_test.go
+++ b/identifier/identifier_spdx_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/IBM/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/licenses"
 )
 
 const (

--- a/identifier/identifier_test.go
+++ b/identifier/identifier_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/IBM/license-scanner/configurer"
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 func Test_generateTextBlocks(t *testing.T) {

--- a/identifier/match_test.go
+++ b/identifier/match_test.go
@@ -7,8 +7,8 @@ package identifier
 import (
 	"testing"
 
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 func Test_generateRegexFromNormalizedText(t *testing.T) {

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/IBM/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/licenses"
 )
 
 var (

--- a/importer/precheck_test.go
+++ b/importer/precheck_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 var fix = flag.Bool("fix", false, "Write/update precheck files if needed.")

--- a/importer/precheck_writer.go
+++ b/importer/precheck_writer.go
@@ -9,9 +9,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/normalizer"
 
-	"github.com/IBM/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/licenses"
 )
 
 var replaceRE = regexp.MustCompile(`(<<.*?>>)`)

--- a/importer/validator.go
+++ b/importer/validator.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/mrutkows/sbom-utility/log"
 
-	"github.com/IBM/license-scanner/debugger"
-	"github.com/IBM/license-scanner/identifier"
-	"github.com/IBM/license-scanner/licenses"
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/debugger"
+	"github.com/CycloneDX/license-scanner/identifier"
+	"github.com/CycloneDX/license-scanner/licenses"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 func ValidateSPDXTemplateWithLicenseText(id, templateFile, textFile, templateDestDir, preCheckDestDir, textDestDir string) (err error) {

--- a/licenses/license.go
+++ b/licenses/license.go
@@ -16,13 +16,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/IBM/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/configurer"
 
 	"github.com/spf13/viper"
 
 	"github.com/mrutkows/sbom-utility/log"
 
-	"github.com/IBM/license-scanner/normalizer"
+	"github.com/CycloneDX/license-scanner/normalizer"
 )
 
 const (

--- a/licenses/license_test.go
+++ b/licenses/license_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/IBM/license-scanner/configurer"
+	"github.com/CycloneDX/license-scanner/configurer"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"github.com/mrutkows/sbom-utility/log"
 
-	"github.com/IBM/license-scanner/cmd"
+	"github.com/CycloneDX/license-scanner/cmd"
 )
 
 var (


### PR DESCRIPTION
* Repo renames (e.g. in README.md)
* Module rename in go.mod and imports

Signed-off-by: Mark Sturdevant <mark.sturdevant@ibm.com>