### PR TITLE
Actions run on main instead of master

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '25 6 * * 2'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
 


### PR DESCRIPTION
* Old repo used master as default branch. Now we use main.

Signed-off-by: Mark Sturdevant <mark.sturdevant@ibm.com>