### PR TITLE
Log error and continue for files too large or containing control chars.

### DIFF
--- a/examples/cli/licensedb/README.md
+++ b/examples/cli/licensedb/README.md
@@ -8,8 +8,8 @@ For license-scanner, we tested the unzipped dataset as-is, and also re-tested af
 
 | Detector                                                                            | Detection rate | Time to scan, sec |
 |:------------------------------------------------------------------------------------|:--------------:|:------------------|
-| [license-scanner (with READMEs)](https://github.com/go-enry/go-license-detector)    | 86%  (776/902) | 24.0              |
-| [license-scanner (without READMEs)](https://github.com/go-enry/go-license-detector) | 82%  (744/902) | 10.8              |
+| [license-scanner (with READMEs)](https://github.com/go-enry/go-license-detector)    | 90%  (813/902) | 25.4              |
+| [license-scanner (without READMEs)](https://github.com/go-enry/go-license-detector) | 87%  (781/902) | 10.7              |
 
 
 Comparison to other projects on that dataset: [here](https://github.com/go-enry/go-license-detector#quality)

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -109,7 +109,8 @@ func IdentifyLicensesInFile(filePath string, options Options, licenseLibrary *li
 		return IdentifierResults{}, err
 	}
 	if fi.Size() > 1000000 {
-		return IdentifierResults{}, fmt.Errorf("file too large (%v > 1000000)", fi.Size())
+		Logger.Errorf("file too large (%v > 1000000)", fi.Size()) // log error, but return nil
+		return IdentifierResults{}, nil
 	}
 
 	b, err := ioutil.ReadFile(filePath)

--- a/normalizer/normalizer.go
+++ b/normalizer/normalizer.go
@@ -152,7 +152,13 @@ func (n *NormalizationData) NormalizeText() error {
 	// Check if the text contains control characters indicative of binary or non-text files.
 	// match against /[\u0000-\u0007\u000E-\u001B]/
 	if ControlCharactersRE.MatchString(n.OriginalText) {
-		return fmt.Errorf("failed to normalize data: invalid input text with control characters")
+		if n.IsTemplate {
+			return fmt.Errorf("failed to normalize data: invalid input text with control characters")
+		} else {
+			Logger.Errorf("failed to normalize data: invalid input text with control characters")
+			n.NormalizedText = ""
+			return nil // continue to allow directory scanning
+		}
 	}
 
 	// remove note tags


### PR DESCRIPTION
Returning the error breaks directory scanning.
So it is logged as an error, but scanning does not stop for the rest of the files in the dir scan.

Fixes: #5

Signed-off-by: Mark Sturdevant <mark.sturdevant@ibm.com>