### PR TITLE
no more config.json copy in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        extra_files: LICENSE config.json ${{env.SBOM_NAME}}
+        extra_files: LICENSE ${{env.SBOM_NAME}}
         # "auto" will use ZIP for Windows, otherwise default is TAR
         compress_assets: auto
         # NOTE: This verbose flag may be removed


### PR DESCRIPTION
We don't have a default config.json anymore.