### PR TITLE
cleaning up license definition

### DIFF
--- a/api/scanner/scan.go
+++ b/api/scanner/scan.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/pflag"
-
+	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/CycloneDX/license-scanner/configurer"
-
 	"github.com/CycloneDX/license-scanner/identifier"
 	"github.com/CycloneDX/license-scanner/licenses"
 	"github.com/CycloneDX/license-scanner/normalizer"
+	"github.com/spf13/pflag"
 )
 
 // NOASSERTION_SPDX_NAME in License SPDX Name signify that the license text passed through the scan without any errors but no match was found
@@ -55,35 +54,10 @@ type ScanSpec struct {
 	LicenseText string
 }
 
+// Licenses is a collection LicenseChoice
 // LicenseChoice is a collection of a License info with expression
 // either license or expression must be set, but not both
-// CycloneDX defines the LicenseChoice is defined here:
-// https://github.com/CycloneDX/cyclonedx-go/blob/7d9a5619d767a252b454e8554d0fc986796ef958/cyclonedx.go#L462-L465
-type LicenseChoice struct {
-	License    *License
-	Expression string
-}
-
-// License is a collection of SPDX ID, name, license text, and license URL
-// CycloneDX license struct defined here:
-// https://github.com/CycloneDX/cyclonedx-go/blob/7d9a5619d767a252b454e8554d0fc986796ef958/cyclonedx.go#L389-L394
-type License struct {
-	ID   string
-	Name string
-	Text *AttachedText
-	URL  string
-}
-
-// AttachedText holds the formatted License Text
-// CycloneDX AttachedText is defined here:
-// https://github.com/CycloneDX/cyclonedx-go/blob/7d9a5619d767a252b454e8554d0fc986796ef958/cyclonedx.go#L52-L56
-type AttachedText struct {
-	Content     string
-	ContentType string
-	Encoding    string
-}
-
-type Licenses []LicenseChoice
+type Licenses []cyclonedx.LicenseChoice
 
 // ScanResult holds the license identification results for a given package
 type ScanResult struct {
@@ -180,8 +154,8 @@ func (s *ScanSpec) ScanLicenseText(licenseLibrary *licenses.LicenseLibrary, resu
 	// if the results are empty, add unknown as the SPDX ID
 	if len(results.Matches) == 0 {
 		// Add NOASSERTION to the LicenseChoice of the SPDX Name for this scan
-		r.CycloneDXLicenses = append(r.CycloneDXLicenses, LicenseChoice{
-			License: &License{
+		r.CycloneDXLicenses = append(r.CycloneDXLicenses, cyclonedx.LicenseChoice{
+			License: &cyclonedx.License{
 				Name: NOASSERTION_SPDX_NAME,
 			},
 		})
@@ -197,13 +171,13 @@ func (s *ScanSpec) ScanLicenseText(licenseLibrary *licenses.LicenseLibrary, resu
 			if family != "" {
 				name = fmt.Sprintf("%s (%s)", name, family)
 			}
-			r.CycloneDXLicenses = append(r.CycloneDXLicenses, LicenseChoice{
-				License: &License{
+			r.CycloneDXLicenses = append(r.CycloneDXLicenses, cyclonedx.LicenseChoice{
+				License: &cyclonedx.License{
 					ID:   id,
 					Name: name,
 					// TODO: verify whether this is acceptable or just expect a single license here
 					URL: strings.Join(licenseLibrary.LicenseMap[id].LicenseInfo.URLs, ","),
-					Text: &AttachedText{
+					Text: &cyclonedx.AttachedText{
 						Content:     licenseLibrary.LicenseMap[id].Text.Content,
 						ContentType: licenseLibrary.LicenseMap[id].Text.ContentType,
 						Encoding:    licenseLibrary.LicenseMap[id].Text.Encoding,

--- a/api/scanner/scan_test.go
+++ b/api/scanner/scan_test.go
@@ -9,13 +9,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
+	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/CycloneDX/license-scanner/api/scanner"
 	"github.com/CycloneDX/license-scanner/configurer"
 	"github.com/CycloneDX/license-scanner/licenses"
 	"github.com/CycloneDX/license-scanner/normalizer"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestScanSpecs_ScanLicenseText(t *testing.T) {
@@ -70,7 +70,7 @@ func TestScanSpecs_ScanLicenseText(t *testing.T) {
 			OriginalText: "this is not a license and must return unknown id",
 			CycloneDXLicenses: scanner.Licenses{
 				{
-					License: &scanner.License{
+					License: &cyclonedx.License{
 						Name: scanner.NOASSERTION_SPDX_NAME,
 					},
 				},
@@ -80,11 +80,11 @@ func TestScanSpecs_ScanLicenseText(t *testing.T) {
 			OriginalText: asyncLicense,
 			CycloneDXLicenses: scanner.Licenses{
 				{
-					License: &scanner.License{
+					License: &cyclonedx.License{
 						ID:   "MIT",
 						Name: "MIT License (MIT)",
 						URL:  "http://www.opensource.org/licenses/mit-license.php,https://opensource.org/licenses/MIT",
-						Text: &scanner.AttachedText{},
+						Text: &cyclonedx.AttachedText{},
 					},
 				},
 			},
@@ -93,11 +93,11 @@ func TestScanSpecs_ScanLicenseText(t *testing.T) {
 			OriginalText: helmetLicense,
 			CycloneDXLicenses: scanner.Licenses{
 				{
-					License: &scanner.License{
+					License: &cyclonedx.License{
 						ID:   "MIT",
 						Name: "MIT License (MIT)",
 						URL:  "http://www.opensource.org/licenses/mit-license.php,https://opensource.org/licenses/MIT",
-						Text: &scanner.AttachedText{},
+						Text: &cyclonedx.AttachedText{},
 					},
 				},
 			},
@@ -106,10 +106,10 @@ func TestScanSpecs_ScanLicenseText(t *testing.T) {
 			OriginalText: goGitLicense,
 			CycloneDXLicenses: scanner.Licenses{
 				{
-					License: &scanner.License{
+					License: &cyclonedx.License{
 						ID:   "Apache-2.0",
 						Name: "Apache License 2.0 (Apache)",
-						Text: &scanner.AttachedText{},
+						Text: &cyclonedx.AttachedText{},
 						URL:  "http://www.apache.org/licenses/LICENSE-2.0",
 					},
 				},
@@ -119,10 +119,10 @@ func TestScanSpecs_ScanLicenseText(t *testing.T) {
 			OriginalText: goPflagLicense,
 			CycloneDXLicenses: scanner.Licenses{
 				{
-					License: &scanner.License{
+					License: &cyclonedx.License{
 						ID:   "BSD-3-Clause",
 						Name: `BSD 3-clause "Revised" License (BSD)`,
-						Text: &scanner.AttachedText{},
+						Text: &cyclonedx.AttachedText{},
 						URL:  "https://spdx.org/licenses/BSD-3-Clause.html,http://www.opensource.org/licenses/BSD-3-Clause,http://www.antlr.org/license.html",
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/CycloneDX/license-scanner
 go 1.18
 
 require (
+	github.com/CycloneDX/cyclonedx-go v0.7.1
 	github.com/CycloneDX/sbom-utility v0.9.3
 	github.com/google/go-cmp v0.5.8
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,11 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
+github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
 github.com/CycloneDX/sbom-utility v0.9.3 h1:kbseWT30dvnnyR1pMg1uqXBmIVXMcf00EMbXpH26pvM=
 github.com/CycloneDX/sbom-utility v0.9.3/go.mod h1:n9hQR2A0Qa7EnC25BJEhY5sDXqUPwMWyAGcypB/H3ik=
+github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -183,7 +186,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/licenses/license.go
+++ b/licenses/license.go
@@ -18,7 +18,6 @@ import (
 	"github.com/CycloneDX/license-scanner/configurer"
 	"github.com/CycloneDX/license-scanner/normalizer"
 	"github.com/CycloneDX/license-scanner/resources"
-
 	"github.com/CycloneDX/sbom-utility/log"
 	"github.com/spf13/viper"
 )


### PR DESCRIPTION
License struct was defined locally in the license scanner when the project was not open. Now, since its open source, cleaning up local definitions and rely on the cyclonedx go client instead.