### PR TITLE
Fix invalid flag processing when no flags passed on command line

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,15 +5,16 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
+	"sort"
+	"time"
+
 	"github.com/CycloneDX/license-scanner/configurer"
 	"github.com/CycloneDX/license-scanner/debugger"
 	"github.com/CycloneDX/license-scanner/identifier"
 	"github.com/CycloneDX/license-scanner/importer"
 	"github.com/CycloneDX/license-scanner/licenses"
 	"github.com/CycloneDX/sbom-utility/log"
-	"os"
-	"sort"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -86,7 +87,7 @@ Please give us feedback at: https://github.com/CycloneDX/license-scanner/issues
 				return listLicenses(cfg)
 			} else if cfg.GetString(configurer.AddAllFlag) != "" {
 				return importer.Import(cfg)
-			} else if cfg.GetString(configurer.UpdateAllFlag) != "" {
+			} else if cfg.GetBool(configurer.UpdateAllFlag) {
 				return importer.Update(cfg)
 			} else {
 				// Otherwise, terminate with an error.


### PR DESCRIPTION
After first building the license-scanner I decided to install/run it to see the help and what flags were available/documented.  However, to my surprise, the executable terminated (exited with no error) and displayed no help.

Debugging this I found that the flag "configurer.UpdateAllFlag" was being retrieved as a `string` (`getString()`) despite it being a `boolean` flag.  Cobra returned no error on the existing code, but returns an empty string (`""`) which was being checked for and caused the "return importer.Update(cfg)" method to be called which has nothing to do so it exits (with no help, message or error return code).

This PR correctly reads the flag as a Bool and actually causes the desired behavior which displays:
```
$ license-scanner
Error: you must provide a file path
Usage:
  license-scanner [flags]

Flags:
  -g, --acceptable          Flag acceptable
      --addAll string       Add licenses from this dir to spdx, spdxPath, custom or customPath dir
      --configName string   Base name for config file (default "config")
      --configPath string   Path to any config files
  -c, --copyrights          Flag copyrights
      --custom string       Custom templates to use (default "default")
      --customPath string   Path to external custom templates to use
  -d, --debug               Enable debug logging
      --dir string          A directory in which to identify licenses
  -f, --file string         A file in which to identify licenses
  -x, --hash                Output file hash
  -h, --help                help for license-scanner
  -k, --keywords            Flag keywords
  -l, --license string      Display match debugging for the given license
      --list                List the license templates to be used
  -n, --normalized          Flag normalized
  -q, --quiet               Set logging to quiet
      --spdx string         Set of embedded SPDX templates to use (default "default")
      --spdxPath string     Path to external SPDX templates to use
      --updateAll           Update existing licenses
  -v, --version             version for license-scanner

```

from the root command's RunE() method logic here:
```
			if f != "" {
				return findLicensesInFile(cfg, f)
			} else if cfg.GetString(configurer.DirFlag) != "" {
				return findLicensesInDirectory(cfg)
			} else if cfg.GetBool(configurer.ListFlag) {
				return listLicenses(cfg)
			} else if cfg.GetString(configurer.AddAllFlag) != "" {
				return importer.Import(cfg)
			} else if cfg.GetBool(configurer.UpdateAllFlag) {
				return importer.Update(cfg)
			} else {
				// Otherwise, terminate with an error.
				return errors.New("you must provide a file path")
			}
```


Fixes: #28 